### PR TITLE
テンプレート指定時は列幅の自動調整を行わない

### DIFF
--- a/src/main/java/io/luchta/forma4j/writer/processor/poi/WorkbookBuilder.java
+++ b/src/main/java/io/luchta/forma4j/writer/processor/poi/WorkbookBuilder.java
@@ -56,7 +56,7 @@ public class WorkbookBuilder {
         return build(WorkbookFactory.create(in), false);
     }
 
-    private Workbook build(Workbook workbook, boolean autoColumnWidthEnabled) {
+    private Workbook build(Workbook workbook, boolean autoSizeColumnEnabled) {
         Map<XlsxCellStyle, CellStyle> styleMap = makeStyleMap(workbook);
 
         for (XlsxSheet sheetModel : model.sheets()) {
@@ -82,7 +82,7 @@ public class WorkbookBuilder {
                 }
             }
 
-            if (!autoColumnWidthEnabled) {
+            if (!autoSizeColumn) {
                 continue;
             }
 

--- a/src/main/java/io/luchta/forma4j/writer/processor/poi/WorkbookBuilder.java
+++ b/src/main/java/io/luchta/forma4j/writer/processor/poi/WorkbookBuilder.java
@@ -43,7 +43,7 @@ public class WorkbookBuilder {
      * @return Excel ワークブック
      */
     public Workbook build() {
-        return build(new XSSFWorkbook());
+        return build(new XSSFWorkbook(), true);
     }
 
     /**
@@ -53,10 +53,10 @@ public class WorkbookBuilder {
      * @return Excel ワークブック
      */
     public Workbook build(InputStream in) throws IOException {
-        return build(WorkbookFactory.create(in));
+        return build(WorkbookFactory.create(in), false);
     }
 
-    private Workbook build(Workbook workbook) {
+    private Workbook build(Workbook workbook, boolean autoColumnWidthEnabled) {
         Map<XlsxCellStyle, CellStyle> styleMap = makeStyleMap(workbook);
 
         for (XlsxSheet sheetModel : model.sheets()) {
@@ -80,6 +80,10 @@ public class WorkbookBuilder {
                     cell.setCellValue(cellModel.value().toString());
                     cell.setCellStyle(styleMap.get(cellModel.style()));
                 }
+            }
+
+            if (!autoColumnWidthEnabled) {
+                continue;
             }
 
             for (int i = 0; i < sheetModel.columnSize(); i++) {


### PR DESCRIPTION
`WorkbookBuilder` クラスの列幅の自動調整がテンプレートを指定していてもONになってしまっており、テンプレートが崩れてしまっていたため、テンプレート指定の時は自動調整が行われないように修正を行なった。