### PR TITLE
Bump com.sun.xml.bind:jaxb-impl from 4.0.3 to 4.0.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.2.4'
 
     implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.1"
-    implementation "com.sun.xml.bind:jaxb-impl:4.0.3"
+    implementation "com.sun.xml.bind:jaxb-impl:4.0.5"
     
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.15.2'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.15.2'


### PR DESCRIPTION
Bumps com.sun.xml.bind:jaxb-impl from 4.0.3 to 4.0.5.

---
updated-dependencies:
- dependency-name: com.sun.xml.bind:jaxb-impl dependency-type: direct:production update-type: version-update:semver-patch ...