### PR TITLE
classifierを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,16 @@
 
 ### Gradle
 
+Gradle
+
 ```gradle
-implementation group: 'io.luchta', name: 'forma4j', version: '1.5.0'
+implementation group: 'io.luchta', name: 'forma4j', version: '1.5.0', classifier: 'all'
+```
+
+Gradle (short)
+
+```gradle
+implementation 'io.luchta:forma4j:1.5.0:all'
 ```
 
 [Maven Repository](https://mvnrepository.com/artifact/io.luchta/forma4j)

--- a/docs/gradle/gradle.md
+++ b/docs/gradle/gradle.md
@@ -6,12 +6,26 @@ forma4jは[Maven Central](https://central.sonatype.com/artifact/io.luchta/forma4
 
 Gradleと組み合わせる場合、`build.gradle` は以下のようになります。
 
+Gradle
+
 ```gradle
 repositories {
   mavenCentral()
 }
 
 dependencies {
-  implementation group: 'io.luchta', name: 'forma4j', version: '1.5.0'
+  implementation group: 'io.luchta', name: 'forma4j', version: '1.5.0', classifier: 'all'
+}
+```
+
+Gradle (short)
+
+```gradle
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation 'io.luchta:forma4j:1.5.0:all'
 }
 ```


### PR DESCRIPTION
gradleのdependenciesの記述にclassifierを追加。shadowjarがallを付与してしまうため。