### PR TITLE
罫線を上下左右別々に設定

### DIFF
--- a/docs/writer/style.md
+++ b/docs/writer/style.md
@@ -7,18 +7,26 @@
 | プロパティ名 | 役割 |
 | --- | --- |
 | border | 罫線の設定を行います。 |
+| border-left | セルの左の罫線の設定を行います。 |
+| border-right | セルの右の罫線の設定を行います。 |
+| border-top | セルの上部の罫線の設定を行います。 |
+| border-bottom | セルの下部の罫線の設定を行います。 |
 | font-size | フォントサイズの設定を行います。|
 | font-style | フォントスタイルの設定を行います。 |
 | wrapText | テキストの折り返し設定を行います。 |
 | background-color | 背景色の設定を行います。 |
 | width | カラム幅の設置を行います。 |
 
-## border
+## border, border-left, border-right, border-top, border-bottom
 
 設定例
 
 ```xml
 <cell style="border:thin;">value</cell>
+<cell style="border-left:thin;">value</cell>
+<cell style="border-right:thin;">value</cell>
+<cell style="border-top:thin;">value</cell>
+<cell style="border-bottom:thin;">value</cell>
 ```
 
 種別

--- a/src/main/java/io/luchta/forma4j/writer/engine/model/cell/style/XlsxCellStyleProperty.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/model/cell/style/XlsxCellStyleProperty.java
@@ -1,5 +1,6 @@
 package io.luchta.forma4j.writer.engine.model.cell.style;
 
+import io.luchta.forma4j.writer.engine.model.cell.style.border.*;
 import io.luchta.forma4j.writer.processor.poi.CellStyleBuilder;
 
 public interface XlsxCellStyleProperty {
@@ -18,6 +19,14 @@ public interface XlsxCellStyleProperty {
                 return new BackGroundColorProperty(value);
             case BorderProperty.NAME:
                 return new BorderProperty(value);
+            case BorderLeftProperty.NAME:
+                return new BorderLeftProperty(value);
+            case BorderRightProperty.NAME:
+                return new BorderRightProperty(value);
+            case BorderTopProperty.NAME:
+                return new BorderTopProperty(value);
+            case BorderBottomProperty.NAME:
+                return new BorderBottomProperty(value);
             case FontSizeProperty.NAME:
                 return new FontSizeProperty(value);
             case FontStyleProperty.NAME:

--- a/src/main/java/io/luchta/forma4j/writer/engine/model/cell/style/border/Border.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/model/cell/style/border/Border.java
@@ -1,19 +1,33 @@
-package io.luchta.forma4j.writer.engine.model.cell.style;
+package io.luchta.forma4j.writer.engine.model.cell.style.border;
 
+import io.luchta.forma4j.writer.engine.model.cell.style.XlsxCellStyleProperty;
 import io.luchta.forma4j.writer.processor.poi.CellStyleBuilder;
 import org.apache.poi.ss.usermodel.BorderStyle;
 
 import java.util.Objects;
 
-public class BorderProperty implements XlsxCellStyleProperty {
-    public static final String NAME = "BORDER";
-    String value;
+/**
+ * 罫線プロパティの基底クラス
+ */
+public abstract class Border implements XlsxCellStyleProperty {
+    /**
+     * プロパティの設定値
+     */
+    protected String value;
 
-    public BorderProperty(String value) {
+    /**
+     * コンストラクタ
+     * @param value プロパティの設定値
+     */
+    public Border(String value) {
         this.value = value;
     }
 
-    private BorderStyle borderStyle() {
+    /**
+     * プロパティの設定値を {@link BorderStyle} に変換する
+     * @return {@link BorderStyle}
+     */
+    protected BorderStyle borderStyle() {
         switch (value.toUpperCase()) {
             case "THIN":
                 return BorderStyle.THIN;
@@ -46,19 +60,23 @@ public class BorderProperty implements XlsxCellStyleProperty {
         }
     }
 
-    @Override
-    public void accept(CellStyleBuilder builder) {
-        builder.setBorder(borderStyle());
-    }
-
+    /**
+     * 同値比較
+     * @param o 比較するオブジェクト
+     * @return true: 同値, false: 同値でない
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        BorderProperty that = (BorderProperty) o;
+        Border that = (Border) o;
         return Objects.equals(value, that.value);
     }
 
+    /**
+     * ハッシュコード
+     * @return ハッシュコード
+     */
     @Override
     public int hashCode() {
         return Objects.hash(value);

--- a/src/main/java/io/luchta/forma4j/writer/engine/model/cell/style/border/BorderBottomProperty.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/model/cell/style/border/BorderBottomProperty.java
@@ -1,0 +1,20 @@
+package io.luchta.forma4j.writer.engine.model.cell.style.border;
+
+import io.luchta.forma4j.writer.processor.poi.CellStyleBuilder;
+
+public class BorderBottomProperty extends Border {
+    public static final String NAME = "BORDER-BOTTOM";
+
+    public BorderBottomProperty(String value) {
+        super(value);
+    }
+
+    /**
+     * 罫線のスタイルを設定する
+     * @param builder CellStyleBuilder
+     */
+    @Override
+    public void accept(CellStyleBuilder builder) {
+        builder.setBorderBottom(borderStyle());
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/model/cell/style/border/BorderLeftProperty.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/model/cell/style/border/BorderLeftProperty.java
@@ -1,0 +1,20 @@
+package io.luchta.forma4j.writer.engine.model.cell.style.border;
+
+import io.luchta.forma4j.writer.processor.poi.CellStyleBuilder;
+
+public class BorderLeftProperty extends Border {
+    public static final String NAME = "BORDER-LEFT";
+
+    public BorderLeftProperty(String value) {
+        super(value);
+    }
+
+    /**
+     * 罫線のスタイルを設定する
+     * @param builder CellStyleBuilder
+     */
+    @Override
+    public void accept(CellStyleBuilder builder) {
+        builder.setBorderLeft(borderStyle());
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/model/cell/style/border/BorderProperty.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/model/cell/style/border/BorderProperty.java
@@ -1,0 +1,20 @@
+package io.luchta.forma4j.writer.engine.model.cell.style.border;
+
+import io.luchta.forma4j.writer.processor.poi.CellStyleBuilder;
+
+public class BorderProperty extends Border {
+    public static final String NAME = "BORDER";
+
+    public BorderProperty(String value) {
+        super(value);
+    }
+
+    /**
+     * 罫線のスタイルを設定する
+     * @param builder CellStyleBuilder
+     */
+    @Override
+    public void accept(CellStyleBuilder builder) {
+        builder.setBorder(borderStyle());
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/model/cell/style/border/BorderRightProperty.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/model/cell/style/border/BorderRightProperty.java
@@ -1,0 +1,20 @@
+package io.luchta.forma4j.writer.engine.model.cell.style.border;
+
+import io.luchta.forma4j.writer.processor.poi.CellStyleBuilder;
+
+public class BorderRightProperty extends Border {
+    public static final String NAME = "BORDER-RIGHT";
+
+    public BorderRightProperty(String value) {
+        super(value);
+    }
+
+    /**
+     * 罫線のスタイルを設定する
+     * @param builder CellStyleBuilder
+     */
+    @Override
+    public void accept(CellStyleBuilder builder) {
+        builder.setBorderRight(borderStyle());
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/model/cell/style/border/BorderTopProperty.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/model/cell/style/border/BorderTopProperty.java
@@ -1,0 +1,20 @@
+package io.luchta.forma4j.writer.engine.model.cell.style.border;
+
+import io.luchta.forma4j.writer.processor.poi.CellStyleBuilder;
+
+public class BorderTopProperty extends Border {
+    public static final String NAME = "BORDER-TOP";
+
+    public BorderTopProperty(String value) {
+        super(value);
+    }
+
+    /**
+     * 罫線のスタイルを設定する
+     * @param builder CellStyleBuilder
+     */
+    @Override
+    public void accept(CellStyleBuilder builder) {
+        builder.setBorderTop(borderStyle());
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/processor/poi/CellStyleBuilder.java
+++ b/src/main/java/io/luchta/forma4j/writer/processor/poi/CellStyleBuilder.java
@@ -37,9 +37,25 @@ public class CellStyleBuilder {
     }
 
     public void setBorder(BorderStyle borderStyle) {
+        setBorderLeft(borderStyle);
+        setBorderTop(borderStyle);
+        setBorderRight(borderStyle);
+        setBorderBottom(borderStyle);
+    }
+
+    public void setBorderLeft(BorderStyle borderStyle) {
         targetStyle.setBorderLeft(borderStyle);
-        targetStyle.setBorderTop(borderStyle);
+    }
+
+    public void setBorderRight(BorderStyle borderStyle) {
         targetStyle.setBorderRight(borderStyle);
+    }
+
+    public void setBorderTop(BorderStyle borderStyle) {
+        targetStyle.setBorderTop(borderStyle);
+    }
+
+    public void setBorderBottom(BorderStyle borderStyle) {
         targetStyle.setBorderBottom(borderStyle);
     }
 

--- a/src/test/resources/writer/style.xml
+++ b/src/test/resources/writer/style.xml
@@ -4,6 +4,10 @@
         <row rowIndex="0" startColumnIndex="0">
             <!-- サポートしているプロパティ -->
             <cell style="border:thin;">border</cell>
+            <cell style="border-top:thin;">border-top</cell>
+            <cell style="border-bottom:thin;">border-bottom</cell>
+            <cell style="border-left:thin;">border-left</cell>
+            <cell style="border-right:thin;">border-right</cell>
             <cell style="font-size:16;">font-size</cell>
             <cell style="font-style:bold;">font-style bold</cell>
             <cell style="font-style:italic;">font-style italic</cell>


### PR DESCRIPTION
以下のスタイルを追加し、罫線を上下左右別々に設定できるように修正を行なった。

- border-left
- border-right
- border-top
- border-bottom