### PR TITLE
cellタグのrowIndex、columnIndex設定時の処理を追加

### DIFF
--- a/src/main/java/io/luchta/forma4j/writer/engine/handler/element/CellHandler.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/handler/element/CellHandler.java
@@ -6,6 +6,7 @@ import io.luchta.forma4j.writer.engine.buffer.BuildBuffer;
 import io.luchta.forma4j.writer.engine.model.cell.XlsxCell;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxCellAddress;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxColumnNumber;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxRowNumber;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxSheetName;
 import io.luchta.forma4j.writer.engine.model.column.XlsxColumnAddress;
 import io.luchta.forma4j.writer.engine.model.column.property.XlsxColumnProperties;
@@ -15,30 +16,61 @@ import io.luchta.forma4j.writer.engine.resolver.StyleResolver;
 import io.luchta.forma4j.writer.engine.model.cell.value.Text;
 import io.luchta.forma4j.writer.engine.model.cell.value.XlsxCellValue;
 
+/**
+ * Cellハンドルクラス
+ */
 public class CellHandler {
     BuildBuffer buffer;
 
+    /**
+     * コンストラクタ
+     * @param buffer
+     */
     public CellHandler(BuildBuffer buffer) {
         this.buffer = buffer;
     }
 
+    /**
+     * ハンドル
+     * <p>
+     * Cellへの書き込み内容の設定処理を行います。
+     * </p>
+     * @param cell
+     */
     public void handle(Cell cell) {
         XlsxCellAddress address = buffer.addressStack().peek();
-		StyleResolver styleResolver = new StyleResolver();
+        if (!cell.rowIndex().isEmpty() || !cell.columnIndex().isEmpty()) {
+            // rowIndex、columnIndexがcellタグに設定されている場合は、cellタグに設定された値を優先する
+            XlsxRowNumber xlsxRowNumber = cell.rowIndex().isEmpty() ? address.rowNumber() : new XlsxRowNumber(cell.rowIndex());
+            XlsxColumnNumber xlsxColumnNumber = cell.columnIndex().isEmpty() ? address.columnNumber() : new XlsxColumnNumber(cell.columnIndex());
+            address = new XlsxCellAddress(address.sheetName(), xlsxRowNumber, xlsxColumnNumber);
+        }
 
+        // cellへの出力内容を設定
+		StyleResolver styleResolver = new StyleResolver();
         XlsxCell xlsxCell = new XlsxCell(address, value(cell), styleResolver.get(cell.style()));
 
+        // 列へのスタイル設定
         XlsxColumnAddress columnAddress = new XlsxColumnAddress(
                 new XlsxSheetName(new Name(address.sheetName().toString())),
                 new XlsxColumnNumber(address.columnNumber().toLong()));
         XlsxColumnProperties columnProperties = styleResolver.getColumnProperties(cell.style());
 
+        // 設定した内容をbufferへセットする
         buffer.accumulator().put(address, xlsxCell);
         for (XlsxColumnProperty columnProperty : columnProperties) {
             buffer.accumulator().putColumnProperties(columnAddress, columnProperty);
         }
     }
 
+    /**
+     * cellへの出力値を取得
+     * <p>
+     * #{hoge} 形式で入力されている場合は変数の評価をして値を取得する。
+     * </p>
+     * @param cell
+     * @return cellへの出力値
+     */
     private XlsxCellValue value(Cell cell) {
         return cell.text().isVariable() ?
                 buffer.variableResolver().get(cell.text().stripMarker()) :

--- a/src/test/java/io/luchta/forma4j/writer/cell/CellTest.java
+++ b/src/test/java/io/luchta/forma4j/writer/cell/CellTest.java
@@ -1,0 +1,66 @@
+package io.luchta.forma4j.writer.cell;
+
+import io.luchta.forma4j.context.databind.json.JsonNode;
+import io.luchta.forma4j.context.databind.json.JsonObject;
+import io.luchta.forma4j.reader.FormaReader;
+import io.luchta.forma4j.writer.FormaWriter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.time.LocalDateTime;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * cellタグに関するテストクラス
+ */
+public class CellTest {
+    static final Logger logger = Logger.getLogger(CellTest.class.getName());
+
+    /**
+     * rowIndexとcolumnIndexを指定してcellへ値を出力するテスト
+     */
+    @Test
+    public void cell_test() throws Exception {
+        // 定義ファイルの読み込み
+        ClassLoader classLoader = getClass().getClassLoader();
+        InputStream in = classLoader.getResource("writer/cell/cell.xml").openStream();
+
+        // 出力ファイルの設定
+        File outFile = Files.createTempFile("test", String.format("%s.xlsx", LocalDateTime.now().toString())).toFile();
+        FileOutputStream out = new FileOutputStream(outFile);
+        String absolutePath = outFile.getAbsolutePath();
+        logger.log(Level.INFO, "xlsxファイル出力先: " + absolutePath);
+
+        // 書き込む内容の設定
+        JsonNode jsonNode = new JsonNode();
+        jsonNode.putVar("value", new JsonObject("あいうえお"));
+
+        // 書き込み
+        FormaWriter sut = new FormaWriter();
+        sut.write(in, out, new JsonObject(jsonNode));
+
+        // 書き込んだ内容のチェック
+        InputStream readerConfig = classLoader.getResource("writer/cell/cell_check.xml").openStream();
+        InputStream outputExcel = new FileInputStream(absolutePath);
+        FormaReader reader = new FormaReader();
+        JsonObject obj = reader.read(readerConfig, outputExcel);
+
+        Object root = obj.getValue();
+        Assertions.assertEquals(true, root instanceof JsonNode);
+
+        JsonObject sheet = ((JsonNode) root).getVar("forma");
+        Assertions.assertEquals(true, sheet.getValue() instanceof JsonNode);
+
+        JsonObject cell = ((JsonNode) sheet.getValue()).getVar("test");
+        Assertions.assertEquals(true, cell.getValue() instanceof JsonNode);
+
+        JsonNode value = ((JsonNode) cell.getValue());
+        Assertions.assertEquals("あいうえお", value.getVar("value").getValue().toString());
+    }
+}

--- a/src/test/resources/writer/cell/cell.xml
+++ b/src/test/resources/writer/cell/cell.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<forma>
+  <sheet name="test">
+    <cell rowIndex="2" columnIndex="3">#{value}</cell>
+  </sheet>
+</forma>

--- a/src/test/resources/writer/cell/cell_check.xml
+++ b/src/test/resources/writer/cell/cell_check.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<forma-reader>
+  <sheet index="0">
+    <cell row="2" col="3" name="value" />
+  </sheet>
+</forma-reader>


### PR DESCRIPTION
rowIndex、columnIndexをcellタグに指定しても設定値が無視されていたが、設定された場合は設定値に従って出力されるように修正。