### PR TITLE
計算式入力時は計算結果を表示

### DIFF
--- a/src/test/java/io/luchta/forma4j/writer/cell/CellTest.java
+++ b/src/test/java/io/luchta/forma4j/writer/cell/CellTest.java
@@ -1,6 +1,7 @@
 package io.luchta.forma4j.writer.cell;
 
 import io.luchta.forma4j.context.databind.json.JsonNode;
+import io.luchta.forma4j.context.databind.json.JsonNodes;
 import io.luchta.forma4j.context.databind.json.JsonObject;
 import io.luchta.forma4j.reader.FormaReader;
 import io.luchta.forma4j.writer.FormaWriter;
@@ -58,9 +59,10 @@ public class CellTest {
         Assertions.assertEquals(true, sheet.getValue() instanceof JsonNode);
 
         JsonObject cell = ((JsonNode) sheet.getValue()).getVar("test");
-        Assertions.assertEquals(true, cell.getValue() instanceof JsonNode);
+        Assertions.assertEquals(true, cell.getValue() instanceof JsonNodes);
 
-        JsonNode value = ((JsonNode) cell.getValue());
-        Assertions.assertEquals("あいうえお", value.getVar("value").getValue().toString());
+        JsonNodes values = ((JsonNodes) cell.getValue());
+        Assertions.assertEquals("あいうえお", values.get(0).getVar("value1").getValue().toString());
+        Assertions.assertEquals("あいうえお", values.get(1).getVar("value2").getValue().toString());
     }
 }

--- a/src/test/resources/writer/cell/cell.xml
+++ b/src/test/resources/writer/cell/cell.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <forma>
   <sheet name="test">
+    <!-- 値 -->
     <cell rowIndex="2" columnIndex="3">#{value}</cell>
+    <!-- 計算式 -->
+    <cell rowIndex="2" columnIndex="4">=D3</cell>
   </sheet>
 </forma>

--- a/src/test/resources/writer/cell/cell_check.xml
+++ b/src/test/resources/writer/cell/cell_check.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <forma-reader>
   <sheet index="0">
-    <cell row="2" col="3" name="value" />
+    <cell row="2" col="3" name="value1" />
+    <cell row="2" col="4" name="value2" />
   </sheet>
 </forma-reader>


### PR DESCRIPTION
先頭が `=` のときは計算式としてセルにセットされ、Excelでは計算結果が表示されるように修正。