### PR TITLE
小数値の読み込み時の不具合を修正

### DIFF
--- a/src/main/java/io/luchta/forma4j/reader/excel/objectreader/CellReader.java
+++ b/src/main/java/io/luchta/forma4j/reader/excel/objectreader/CellReader.java
@@ -104,7 +104,11 @@ public class CellReader implements ObjectReader {
                     // セルの値が数値かつ日付フォーマットであれば日付として読み込みを行う
                     return new JsonObject(cell.getLocalDateTimeCellValue());
                 } else {
-                    return new JsonObject(new BigDecimal(cellValue.getNumberValue()));
+                    double numericValue = cellValue.getNumberValue();
+                    if (numericValue % 1 == 0) {
+                        return new JsonObject(new BigDecimal(((Double) cellValue.getNumberValue()).intValue()));
+                    }
+                    return new JsonObject(new BigDecimal(String.valueOf(cellValue.getNumberValue())));
                 }
             case BOOLEAN:
                 return new JsonObject(cellValue.getBooleanValue());

--- a/src/test/java/io/luchta/forma4j/reader/cell/CellTest.java
+++ b/src/test/java/io/luchta/forma4j/reader/cell/CellTest.java
@@ -1,5 +1,6 @@
 package io.luchta.forma4j.reader.cell;
 
+import io.luchta.forma4j.context.databind.convert.JsonSerializer;
 import io.luchta.forma4j.context.databind.json.JsonNode;
 import io.luchta.forma4j.context.databind.json.JsonNodes;
 import io.luchta.forma4j.context.databind.json.JsonObject;
@@ -190,9 +191,9 @@ public class CellTest {
 
             JsonNodes value = ((JsonNodes) cell.getValue());
 
-            Assertions.assertEquals(new BigDecimal(1), value.get(0).getVar("value1").getValue());
-            Assertions.assertEquals(new BigDecimal(1.3), value.get(1).getVar("value2").getValue());
-            Assertions.assertEquals(new BigDecimal(18000000), value.get(2).getVar("value3").getValue());
+            Assertions.assertEquals(new BigDecimal("1"), value.get(0).getVar("value1").getValue());
+            Assertions.assertEquals(new BigDecimal("1.3"), value.get(1).getVar("value2").getValue());
+            Assertions.assertEquals(new BigDecimal("18000000"), value.get(2).getVar("value3").getValue());
         }
     }
 


### PR DESCRIPTION
`1.05` が `1.0500000000000000444089209850062616169452667236328125` に変換されて読み込まれる不具合への対応。