### PR TITLE
構文エラーのときのメッセージを修正

### DIFF
--- a/src/main/java/io/luchta/forma4j/context/syntax/SyntaxErrors.java
+++ b/src/main/java/io/luchta/forma4j/context/syntax/SyntaxErrors.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class SyntaxErrors implements Iterable<SyntaxError> {
 
-    List<SyntaxError> list;
+    private List<SyntaxError> list;
 
     public SyntaxErrors() {
         list = new ArrayList<>();
@@ -26,6 +26,14 @@ public class SyntaxErrors implements Iterable<SyntaxError> {
 
     public boolean hasErrors() {
         return size() != 0;
+    }
+
+    public String errorMessage() {
+        String message = "";
+        for (SyntaxError syntaxError : list) {
+            message += "  " + syntaxError.getMessage() + "\n";
+        }
+        return message;
     }
 
     @Override

--- a/src/main/java/io/luchta/forma4j/reader/FormaReader.java
+++ b/src/main/java/io/luchta/forma4j/reader/FormaReader.java
@@ -77,7 +77,7 @@ public class FormaReader {
         TagTree tree = compiler.compile(config, syntaxErrors);
 
         if (syntaxErrors.hasErrors()) {
-            throw new IllegalArgumentException("設定ファイルの構文にエラーがあります");
+            throw new IllegalArgumentException("設定ファイルの構文にエラーがあります\n" + syntaxErrors.errorMessage());
         }
 
         ExcelReader excelReader = new ExcelReader();

--- a/src/main/java/io/luchta/forma4j/reader/compile/relation/RelationAnalysis.java
+++ b/src/main/java/io/luchta/forma4j/reader/compile/relation/RelationAnalysis.java
@@ -22,7 +22,7 @@ public class RelationAnalysis {
         TagTrees children = tree.getChildren();
         for (TagTree child : children) {
             if (!child.getTag().isSheet()) {
-                SyntaxError syntaxError = new SyntaxError("forma-reader は子要素に指定できるのは sheet タグのみです");
+                SyntaxError syntaxError = new SyntaxError("forma-reader が子要素に指定できるのは sheet タグのみです");
                 syntaxErrors.add(syntaxError);
                 break;
             }


### PR DESCRIPTION
構文エラーがあった時に `設定ファイルの構文にエラーがあります` だけで、エラーの内容が分からないため、メッセージの内容を詳細化する。